### PR TITLE
Render graph with ranked nodes

### DIFF
--- a/src/graph.ts
+++ b/src/graph.ts
@@ -3,6 +3,8 @@ import { EdgeHTML } from './sidebar/edge_html';
 import { ModuleList } from './sidebar/module_repo';
 import { SensorList } from './sidebar/sensor_html';
 import { Network } from './network';
+import { vCoordUnconnectedNode } from './main/graph_html';
+import { find } from 'lodash';
 
 export const NETWORK_NODE_ID: string = "NET";
 
@@ -156,7 +158,7 @@ export class Graph {
     GraphHTML.reset()
   }
 
-  add_sensor(sensor: Sensor): boolean {
+  add_sensor(sensor: Sensor, outTop: number, inTop: number, outLeft: number, inLeft: number): boolean {
     if (this._exists(sensor.id)) {
       console.error('sensor id already exists')
       return false
@@ -171,7 +173,7 @@ export class Graph {
         outgoing_buttons: [],
         incoming_buttons: [],
       }
-      let html = GraphHTML.renderSensor(sensor.id, inner);
+      let html = GraphHTML.renderSensor(sensor.id, inner, outTop, inTop, outLeft, inLeft);
       inner.htmlOut = html[0]
       inner.htmlIn = html[1]
       this.sensors[sensor.id] = inner;
@@ -220,10 +222,10 @@ export class Graph {
 
   add_module(mod: Module): void {
     let id = this._genEntityID(mod.globalId)
-    this.addModuleWithId(mod, id)
+    this.addModuleWithId(mod, id, -1, -1)
   }
 
-  addModuleWithId(mod: Module, id: string): void {
+  addModuleWithId(mod: Module, id: string, top: number, left: number): void {
     let inner: ModuleInner = {
       id: id,
       value: mod,
@@ -236,7 +238,7 @@ export class Graph {
       outgoing_buttons: [],
       incoming_buttons: [],
     }
-    inner.html = GraphHTML.renderModule(id, inner);
+    inner.html = GraphHTML.renderModule(id, inner, top, left);
     GraphHTML.renderModuleProperties(inner)
     ModuleList.addModule(id)
     this.modules[id] = inner;
@@ -636,17 +638,186 @@ export class Graph {
     return format;
   }
 
+
+  adjacencyMatrix = new Array()
+  nodeIDToIndex = new Map()
+  indexToNodeID = new Map()
+  nodeDepth: number[]
+  levelOrder: number[]
+  counterMap = new Map() //helper map for levelOrder
+  numNodes = 0
+  STEP_SIZE = 170
+  INITIAL_HEIGHT = 100
+  MAX_WIDTH = 800
+
   setGraphFormat(f: GraphFormat) {
     // TODO: only apply the delta
     this.reset()
-    f.sensors.forEach(sensor => this.add_sensor(sensor))
-    f.moduleIds.forEach(id => {
-      let mod = Network.checkModuleRepo(id.global)
-      this.addModuleWithId(mod, id.local)
-    })
+    this.numNodes = f.sensors.length * 2 + f.moduleIds.length
+
+    //mapping each node to an index to use in adj mat, getNodeDepth
+    for(let i = 0; i < f.sensors.length; i++){
+      this.nodeIDToIndex.set(f.sensors[i].id + 'OUT', 2 * i)
+      this.nodeIDToIndex.set(f.sensors[i].id + 'IN', 2 * i + 1)
+      this.indexToNodeID.set(2 * i, f.sensors[i].id + 'OUT')
+      this.indexToNodeID.set(2 * i + 1, f.sensors[i].id + 'IN')
+    }
+
+    for(let i = 0; i < f.moduleIds.length; i++){
+      this.nodeIDToIndex.set(f.moduleIds[i].local, i + f.sensors.length * 2)
+      this.indexToNodeID.set(i + f.sensors.length * 2, f.moduleIds[i].local)
+
+    }
+
+    //build adjacency matrix
+    for(let i = 0; i < this.numNodes; i++){
+      this.adjacencyMatrix[i] = new Array()
+      for(let j = 0; j < this.numNodes; j++){
+        this.adjacencyMatrix[i][j] = 0
+      }
+    }
+    
+    for(let i = 0; i < f.edges.data.length; i++){
+      if(this.nodeIDToIndex.get(f.edges.data[i].out_id + "OUT") == undefined){
+        this.adjacencyMatrix[this.nodeIDToIndex.get(f.edges.data[i].out_id)][this.nodeIDToIndex.get(f.edges.data[i].module_id)] = 1
+      } else {
+        this.adjacencyMatrix[this.nodeIDToIndex.get(f.edges.data[i].out_id + "OUT")][this.nodeIDToIndex.get(f.edges.data[i].module_id)] = 1
+      }
+    }
+
+    for(let i = 0; i < f.edges.state.length; i++){
+      this.adjacencyMatrix[this.nodeIDToIndex.get(f.edges.state[i].module_id)][this.nodeIDToIndex.get(f.edges.state[i].sensor_id + "IN")] = 1
+    }
+
+    this.nodeDepth = new Array()
+    for(let i = 0; i < this.numNodes; i++){
+      this.nodeDepth[i] = 0
+    }
+    for(let i = 0; i < this.numNodes; i++){
+      this.getNodeDepth(i)
+    }
+
+    this.counterMap = new Map()
+    //initializing heights for counterMap
+    for(let i = 0; i < this.numNodes; i++){
+      //if height currently is not in map
+      if(this.counterMap.get(this.nodeDepth[i]) == undefined){
+        this.counterMap.set(this.nodeDepth[i], 1)
+      }
+    }
+
+    this.levelOrder = new Array()
+    for(let i = 0; i < this.numNodes; i++){
+      this.levelOrder[i] = 0
+    }
+    for(let i = 0; i < this.numNodes; i++){
+      if(this.nodeDepth[i] == 100){
+        this.getLevelOrderTraversal(i)
+      }
+    }
+
+    console.log(this.levelOrder)
+
+    let numAtDepth = new Map()
+    for(let i = 0; i < this.numNodes; i++){
+      if(numAtDepth.get(this.nodeDepth[i]) == undefined){
+        numAtDepth.set(this.nodeDepth[i], 1)
+      } else {
+        numAtDepth.set(this.nodeDepth[i], numAtDepth.get(this.nodeDepth[i]) + 1)
+      }
+    }
+
+    let nodeHorizontal = new Array()
+    for(let i = 0; i < this.numNodes; i++){
+      nodeHorizontal[i] = this.MAX_WIDTH / (numAtDepth.get(this.nodeDepth[i]) + 1) * this.levelOrder[i]
+    }
+
+    vCoordUnconnectedNode.coord = 0
+
+    for(let i = 0; i < f.sensors.length; i++){
+      this.add_sensor(f.sensors[i], this.nodeDepth[2 * i], this.nodeDepth[2*i+1], nodeHorizontal[2 * i], nodeHorizontal[2*i + 1])
+    }
+    for(let i = 0; i < f.moduleIds.length; i++){
+      let mod = Network.checkModuleRepo(f.moduleIds[i].global)
+      this.addModuleWithId(mod, f.moduleIds[i].local, this.nodeDepth[f.sensors.length * 2 + i], nodeHorizontal[f.sensors.length * 2 + i])
+    }
+
     f.edges.data.forEach(edge => this.add_data_edge(edge))
     f.edges.state.forEach(edge => this.add_state_edge(edge))
     f.edges.network.forEach(edge => this.add_network_edge(edge))
     f.edges.interval.forEach(interval => this.set_interval(interval))
   }
+
+  getNodeDepth(nodeIndex: number){
+    if(this.nodeDepth[nodeIndex] != 0){
+      return this.nodeDepth[nodeIndex]
+    } 
+    let children = this.findNodeChildren(nodeIndex)
+    let parents = this.findNodeParent(nodeIndex)
+    if(children.length == 0){
+      if(parents.length == 0){
+        this.nodeDepth[nodeIndex] = -1
+        return -1
+      }
+    }
+    if(parents.length == 0){
+      this.nodeDepth[nodeIndex] = this.INITIAL_HEIGHT
+      return this.INITIAL_HEIGHT
+    }
+    else {
+      let max = 0;
+      parents.forEach(parent => {
+        max = Math.max(max, this.getNodeDepth(parent))
+      });
+      this.nodeDepth[nodeIndex] = max + this.STEP_SIZE
+      return max + this.STEP_SIZE
+    }
+  }
+
+  getLevelOrderTraversal(rootIndex: number){
+    if(this.levelOrder[rootIndex] != 0){
+      return this.levelOrder[rootIndex]
+    }
+    let queue = new Array()
+    queue.push(rootIndex)
+    while(queue.length != 0){
+      let dq = queue.shift()
+      if(this.levelOrder[dq] == 0){
+        this.levelOrder[dq] = this.counterMap.get(this.nodeDepth[dq])
+        console.log(this.indexToNodeID.get(dq))
+        console.log(this.levelOrder)
+        this.counterMap.set(this.nodeDepth[dq], this.counterMap.get(this.nodeDepth[dq]) + 1)
+        let children = this.findNodeChildren(dq)
+        children.forEach(element => {
+          queue.push(element)
+        });        
+      }
+      
+    }
+    
+  }
+
+  //returns indicies of the node's children
+  findNodeChildren(nodeIndex: number){
+    let result = new Array
+    for(let i = 0; i < this.numNodes; i++){
+      if(this.adjacencyMatrix[nodeIndex][i] == 1){
+        result.push(i)
+      }
+    }
+    return result
+  }
+
+  //returns indicies of the node's parents
+  findNodeParent(nodeIndex: number){
+    let result = new Array
+    for(let i = 0; i < this.numNodes; i++){
+      if(this.adjacencyMatrix[i][nodeIndex] == 1){
+        result.push(i)
+      }
+    }
+    return result
+  }
+
+
 }

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -5,7 +5,6 @@ import { SensorList } from './sidebar/sensor_html';
 import { Network } from './network';
 import { vCoordUnconnectedNode } from './main/graph_html';
 import { GraphCoord } from './graphCoord';
-import { find } from 'lodash';
 
 export const NETWORK_NODE_ID: string = "NET";
 
@@ -174,9 +173,6 @@ export class Graph {
         outgoing_buttons: [],
         incoming_buttons: [],
       }
-      if(typeof outTop == 'undefined' && typeof inTop == 'undefined'){
-
-      }
       let html = GraphHTML.renderSensor(sensor.id, inner, outTop, inTop, outLeft, inLeft);
       inner.htmlOut = html[0]
       inner.htmlIn = html[1]
@@ -242,7 +238,7 @@ export class Graph {
       outgoing_buttons: [],
       incoming_buttons: [],
     }
-    if(typeof top == undefined){
+    if(top == null){
       inner.html = GraphHTML.renderModule(id, inner)
     } else {
       inner.html = GraphHTML.renderModule(id, inner, top, left);
@@ -645,15 +641,6 @@ export class Graph {
       .sort((a, b) => a.module_id.localeCompare(b.module_id))
     return format;
   }
-
-  adjacencyMatrix = new Array()
-  nodeIDToIndex = new Map()
-  levelOrder: number[]
-  counterMap = new Map() //helper map for levelOrder
-  numNodes = 0
-  STEP_SIZE = 170
-  INITIAL_HEIGHT = 100
-  MAX_WIDTH = 800
 
   setGraphFormat(f: GraphFormat) {
     // TODO: only apply the delta

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -4,6 +4,7 @@ import { ModuleList } from './sidebar/module_repo';
 import { SensorList } from './sidebar/sensor_html';
 import { Network } from './network';
 import { vCoordUnconnectedNode } from './main/graph_html';
+import { GraphCoord } from './graphCoord';
 import { find } from 'lodash';
 
 export const NETWORK_NODE_ID: string = "NET";
@@ -645,10 +646,8 @@ export class Graph {
     return format;
   }
 
-
   adjacencyMatrix = new Array()
   nodeIDToIndex = new Map()
-  nodeDepth: number[]
   levelOrder: number[]
   counterMap = new Map() //helper map for levelOrder
   numNodes = 0
@@ -660,75 +659,15 @@ export class Graph {
     // TODO: only apply the delta
     this.reset()
     vCoordUnconnectedNode.coord = -30
-    this.numNodes = f.sensors.length * 2 + f.moduleIds.length
-
-    //mapping each node to an index
-    for(let i = 0; i < f.sensors.length; i++){
-      this.nodeIDToIndex.set(f.sensors[i].id + 'OUT', 2 * i)
-      this.nodeIDToIndex.set(f.sensors[i].id + 'IN', 2 * i + 1)
-
-    }
-
-    for(let i = 0; i < f.moduleIds.length; i++){
-      this.nodeIDToIndex.set(f.moduleIds[i].local, i + f.sensors.length * 2)
-
-    }
-
-    //build adjacency matrix
-    this.buildAdjacencyMatrix(f)
-
-    this.nodeDepth = new Array()
-    for(let i = 0; i < this.numNodes; i++){
-      this.nodeDepth[i] = 0
-    }
-    for(let i = 0; i < this.numNodes; i++){
-      this.getNodeDepth(i)
-    }
-    for(let i = 0; i < this.numNodes; i++){
-      if(this.nodeDepth[i] == -1){
-        this.nodeDepth[i] = undefined
-      }
-    }
-
-    this.counterMap = new Map()
-    //initializing heights for counterMap
-    for(let i = 0; i < this.numNodes; i++){
-      //if height currently is not in map
-      if(this.counterMap.get(this.nodeDepth[i]) == undefined){
-        this.counterMap.set(this.nodeDepth[i], 1)
-      }
-    }
-
-    this.levelOrder = new Array()
-    for(let i = 0; i < this.numNodes; i++){
-      this.levelOrder[i] = 0
-    }
-    for(let i = 0; i < this.numNodes; i++){
-      if(this.nodeDepth[i] == 100){
-        this.getLevelOrderTraversal(i)
-      }
-    }
-
-    let numAtDepth = new Map()
-    for(let i = 0; i < this.numNodes; i++){
-      if(numAtDepth.get(this.nodeDepth[i]) == undefined){
-        numAtDepth.set(this.nodeDepth[i], 1)
-      } else {
-        numAtDepth.set(this.nodeDepth[i], numAtDepth.get(this.nodeDepth[i]) + 1)
-      }
-    }
-
-    let nodeHorizontal = new Array()
-    for(let i = 0; i < this.numNodes; i++){
-      nodeHorizontal[i] = this.MAX_WIDTH / (numAtDepth.get(this.nodeDepth[i]) + 1) * this.levelOrder[i]
-    }
+    let graphCoord = new GraphCoord()
+    let [nodeDepth, nodeHorizontal] = graphCoord.findCoords(f)
 
     for(let i = 0; i < f.sensors.length; i++){
-      this.add_sensor(f.sensors[i], this.nodeDepth[2 * i], this.nodeDepth[2*i+1], nodeHorizontal[2 * i], nodeHorizontal[2*i + 1])
+      this.add_sensor(f.sensors[i], nodeDepth[2 * i], nodeDepth[2*i+1], nodeHorizontal[2 * i], nodeHorizontal[2*i + 1])
     }
     for(let i = 0; i < f.moduleIds.length; i++){
       let mod = Network.checkModuleRepo(f.moduleIds[i].global)
-      this.addModuleWithId(mod, f.moduleIds[i].local, this.nodeDepth[f.sensors.length * 2 + i], nodeHorizontal[f.sensors.length * 2 + i])
+      this.addModuleWithId(mod, f.moduleIds[i].local, nodeDepth[f.sensors.length * 2 + i], nodeHorizontal[f.sensors.length * 2 + i])
     }
 
     f.edges.data.forEach(edge => this.add_data_edge(edge))
@@ -736,96 +675,4 @@ export class Graph {
     f.edges.network.forEach(edge => this.add_network_edge(edge))
     f.edges.interval.forEach(interval => this.set_interval(interval))
   }
-
-  buildAdjacencyMatrix(f: GraphFormat){
-    for(let i = 0; i < this.numNodes; i++){
-      this.adjacencyMatrix[i] = new Array()
-      for(let j = 0; j < this.numNodes; j++){
-        this.adjacencyMatrix[i][j] = 0
-      }
-    }
-    
-    for(let i = 0; i < f.edges.data.length; i++){
-      if(this.nodeIDToIndex.get(f.edges.data[i].out_id + "OUT") == undefined){
-        this.adjacencyMatrix[this.nodeIDToIndex.get(f.edges.data[i].out_id)][this.nodeIDToIndex.get(f.edges.data[i].module_id)] = 1
-      } else {
-        this.adjacencyMatrix[this.nodeIDToIndex.get(f.edges.data[i].out_id + "OUT")][this.nodeIDToIndex.get(f.edges.data[i].module_id)] = 1
-      }
-    }
-
-    for(let i = 0; i < f.edges.state.length; i++){
-      this.adjacencyMatrix[this.nodeIDToIndex.get(f.edges.state[i].module_id)][this.nodeIDToIndex.get(f.edges.state[i].sensor_id + "IN")] = 1
-    }
-  }
-
-  getNodeDepth(nodeIndex: number){
-    if(this.nodeDepth[nodeIndex] != 0){
-      return this.nodeDepth[nodeIndex]
-    } 
-    let children = this.findNodeChildren(nodeIndex)
-    let parents = this.findNodeParent(nodeIndex)
-    if(children.length == 0){
-      if(parents.length == 0){
-        this.nodeDepth[nodeIndex] = -1
-        return -1
-      }
-    }
-    if(parents.length == 0){
-      this.nodeDepth[nodeIndex] = this.INITIAL_HEIGHT
-      return this.INITIAL_HEIGHT
-    }
-    else {
-      let max = 0;
-      parents.forEach(parent => {
-        max = Math.max(max, this.getNodeDepth(parent))
-      });
-      this.nodeDepth[nodeIndex] = max + this.STEP_SIZE
-      return max + this.STEP_SIZE
-    }
-  }
-
-  getLevelOrderTraversal(rootIndex: number){
-    if(this.levelOrder[rootIndex] != 0){
-      return this.levelOrder[rootIndex]
-    }
-    let queue = new Array()
-    queue.push(rootIndex)
-    while(queue.length != 0){
-      let dq = queue.shift()
-      if(this.levelOrder[dq] == 0){
-        this.levelOrder[dq] = this.counterMap.get(this.nodeDepth[dq])
-        this.counterMap.set(this.nodeDepth[dq], this.counterMap.get(this.nodeDepth[dq]) + 1)
-        let children = this.findNodeChildren(dq)
-        children.forEach(element => {
-          queue.push(element)
-        });        
-      }
-      
-    }
-    
-  }
-
-  //returns indicies of the node's children
-  findNodeChildren(nodeIndex: number){
-    let result = new Array
-    for(let i = 0; i < this.numNodes; i++){
-      if(this.adjacencyMatrix[nodeIndex][i] == 1){
-        result.push(i)
-      }
-    }
-    return result
-  }
-
-  //returns indicies of the node's parents
-  findNodeParent(nodeIndex: number){
-    let result = new Array
-    for(let i = 0; i < this.numNodes; i++){
-      if(this.adjacencyMatrix[i][nodeIndex] == 1){
-        result.push(i)
-      }
-    }
-    return result
-  }
-
-
 }

--- a/src/graphCoord.ts
+++ b/src/graphCoord.ts
@@ -1,0 +1,175 @@
+import { GraphFormat } from './graph';
+
+export class GraphCoord {
+
+  adjacencyMatrix = new Array()
+  nodeIDToIndex = new Map()
+  nodeDepth: number[]
+  levelOrder: number[]
+  counterMap = new Map() //helper map for levelOrder
+  STEP_SIZE = 170
+  INITIAL_HEIGHT = 100
+  MAX_WIDTH = 800
+
+  findCoords(f: GraphFormat){
+    let numNodes = this.getNumNodes(f)
+    this.buildNodeIDToIndex(f)
+    this.buildAdjacencyMatrix(f)
+    this.nodeDepth = new Array()
+
+    for(let i = 0; i < numNodes; i++){
+      this.nodeDepth[i] = 0
+    }
+    for(let i = 0; i < numNodes; i++){
+      this.getNodeDepth(i)
+    }
+    for(let i = 0; i < numNodes; i++){
+      if(this.nodeDepth[i] == -1){
+        this.nodeDepth[i] = undefined
+      }
+    }
+
+    this.counterMap = new Map()
+    //initializing heights for counterMap
+    for(let i = 0; i < numNodes; i++){
+      //if height currently is not in map
+      if(this.counterMap.get(this.nodeDepth[i]) == undefined){
+        this.counterMap.set(this.nodeDepth[i], 1)
+      }
+    }
+
+    this.levelOrder = new Array()
+    for(let i = 0; i < numNodes; i++){
+      this.levelOrder[i] = 0
+    }
+    for(let i = 0; i < numNodes; i++){
+      if(this.nodeDepth[i] == this.INITIAL_HEIGHT){
+        this.getLevelOrderTraversal(i)
+      }
+    }
+
+    let numAtDepth = new Map()
+    for(let i = 0; i < numNodes; i++){
+      if(numAtDepth.get(this.nodeDepth[i]) == undefined){
+        numAtDepth.set(this.nodeDepth[i], 1)
+      } else {
+        numAtDepth.set(this.nodeDepth[i], numAtDepth.get(this.nodeDepth[i]) + 1)
+      }
+    }
+
+    let nodeHorizontal = new Array()
+    for(let i = 0; i < numNodes; i++){
+      nodeHorizontal[i] = this.MAX_WIDTH / (numAtDepth.get(this.nodeDepth[i]) + 1) * this.levelOrder[i]
+    }
+
+    return [this.nodeDepth, nodeHorizontal]
+  }
+
+  private getNumNodes(f: GraphFormat){
+    return f.sensors.length * 2 + f.moduleIds.length
+  }
+
+  private buildNodeIDToIndex(f: GraphFormat){
+    for(let i = 0; i < f.sensors.length; i++){
+      this.nodeIDToIndex.set(f.sensors[i].id + 'OUT', 2 * i)
+      this.nodeIDToIndex.set(f.sensors[i].id + 'IN', 2 * i + 1)
+    }
+
+    for(let i = 0; i < f.moduleIds.length; i++){
+      this.nodeIDToIndex.set(f.moduleIds[i].local, i + f.sensors.length * 2)
+    }
+  }
+
+  private buildAdjacencyMatrix(f: GraphFormat){
+    let numNodes = this.getNumNodes(f)
+    for(let i = 0; i < numNodes; i++){
+      this.adjacencyMatrix[i] = new Array()
+      for(let j = 0; j < numNodes; j++){
+        this.adjacencyMatrix[i][j] = 0
+      }
+    }
+    
+    for(let i = 0; i < f.edges.data.length; i++){
+      if(this.nodeIDToIndex.get(f.edges.data[i].out_id + "OUT") == undefined){
+        this.adjacencyMatrix[this.nodeIDToIndex.get(f.edges.data[i].out_id)][this.nodeIDToIndex.get(f.edges.data[i].module_id)] = 1
+      } else {
+        this.adjacencyMatrix[this.nodeIDToIndex.get(f.edges.data[i].out_id + "OUT")][this.nodeIDToIndex.get(f.edges.data[i].module_id)] = 1
+      }
+    }
+
+    for(let i = 0; i < f.edges.state.length; i++){
+      this.adjacencyMatrix[this.nodeIDToIndex.get(f.edges.state[i].module_id)][this.nodeIDToIndex.get(f.edges.state[i].sensor_id + "IN")] = 1
+    }
+  }
+
+  getNodeDepth(nodeIndex: number){
+    if(this.nodeDepth[nodeIndex] != 0){
+      return this.nodeDepth[nodeIndex]
+    } 
+    let children = this.findNodeChildren(nodeIndex)
+    let parents = this.findNodeParent(nodeIndex)
+    if(children.length == 0){
+      if(parents.length == 0){
+        this.nodeDepth[nodeIndex] = -1
+        return -1
+      }
+    }
+    if(parents.length == 0){
+      this.nodeDepth[nodeIndex] = this.INITIAL_HEIGHT
+      return this.INITIAL_HEIGHT
+    }
+    else {
+      let max = 0;
+      parents.forEach(parent => {
+        max = Math.max(max, this.getNodeDepth(parent))
+      });
+      this.nodeDepth[nodeIndex] = max + this.STEP_SIZE
+      return max + this.STEP_SIZE
+    }
+  }
+
+  getLevelOrderTraversal(rootIndex: number,){
+    if(this.levelOrder[rootIndex] != 0){
+      return this.levelOrder[rootIndex]
+    }
+    let queue = new Array()
+    queue.push(rootIndex)
+    while(queue.length != 0){
+      let dq = queue.shift()
+      if(this.levelOrder[dq] == 0){
+        this.levelOrder[dq] = this.counterMap.get(this.nodeDepth[dq])
+        this.counterMap.set(this.nodeDepth[dq], this.counterMap.get(this.nodeDepth[dq]) + 1)
+        let children = this.findNodeChildren(dq)
+        children.forEach(element => {
+          queue.push(element)
+        });        
+      }
+      
+    }
+    
+  }
+
+  //returns indicies of the node's children
+  findNodeChildren(nodeIndex: number){
+    let result = new Array
+    for(let i = 0; i < this.adjacencyMatrix.length; i++){
+      if(this.adjacencyMatrix[nodeIndex][i] == 1){
+        result.push(i)
+      }
+    }
+    return result
+  }
+
+  //returns indicies of the node's parents
+  findNodeParent(nodeIndex: number){
+    let result = new Array
+    for(let i = 0; i < this.adjacencyMatrix.length; i++){
+      if(this.adjacencyMatrix[i][nodeIndex] == 1){
+        result.push(i)
+      }
+    }
+    return result
+  }
+  
+  
+  }

--- a/src/main/graph_html.ts
+++ b/src/main/graph_html.ts
@@ -11,13 +11,19 @@ const LEFT_DELTA = 170;
 const COLS = 4
 let nnodes = 0
 
+let vCoordUnconnectedNode = {
+  coord: -30,
+};
+export { vCoordUnconnectedNode }
+
 function _nextNodeLocation(): { top: number, left: number } {
   let row = Math.floor(nnodes / COLS)
   let col = nnodes - row * COLS
   nnodes += 1
+  vCoordUnconnectedNode.coord = vCoordUnconnectedNode.coord + 100
   return {
-    top: TOP_INITIAL + row * TOP_DELTA,
-    left: LEFT_INITIAL + col * LEFT_DELTA,
+    top: vCoordUnconnectedNode.coord,
+    left: 900,
   }
 }
 
@@ -127,6 +133,8 @@ export module GraphHTML {
     }
   }
 
+  //if top == -1, then go with _nextNodeLocation(), otherwise use
+  //given height
   function _renderNode(
     id: string,
     ty: NodeType,
@@ -136,14 +144,23 @@ export module GraphHTML {
     outputs: string[],
     outgoingButtons: HTMLButtonElement[],
     incomingButtons: HTMLButtonElement[],
+    top: number,
+    left: number
   ): HTMLDivElement {
     let node = document.createElement("div");
-    let loc = _nextNodeLocation()
     node.className = "node " + ty;
-    node.style.top = loc.top.toString() + 'px';
-    node.style.left = loc.left.toString() + 'px';
-    node.setAttribute('top', loc.top.toString())
-    node.setAttribute('left', loc.left.toString())
+    if(top == -1){
+      let loc = _nextNodeLocation()
+      node.style.top = loc.top.toString() + 'px';
+      node.setAttribute('top', loc.top.toString())
+      node.style.left = loc.left.toString() + 'px';
+      node.setAttribute('left', loc.left.toString())
+    } else {
+      node.style.top = top.toString() + 'px';
+      node.setAttribute('top', top.toString())
+      node.style.left = left.toString() + 'px';
+      node.setAttribute('left', left.toString())
+    }
     let header = document.createElement('div');
     header.className = 'node-header'
     inputs.forEach(function(val) {
@@ -216,7 +233,7 @@ export module GraphHTML {
     }
   }
 
-  export function renderModule(id: string, inner: ModuleInner): HTMLDivElement {
+  export function renderModule(id: string, inner: ModuleInner, top: number, left: number): HTMLDivElement {
     let node = _renderNode(
       id,
       'module',
@@ -226,14 +243,21 @@ export module GraphHTML {
       inner.value.returns,
       inner.outgoing_buttons,
       inner.incoming_buttons,
+      top,
+      left
     )
     _dragElement(node, inner.outgoing_edges, inner.incoming_edges, inner);
     return node
   }
 
+  //set outTop, inTop to -1 if don't have values for them
   export function renderSensor(
     id: string,
     inner: SensorInner,
+    outTop: number,
+    inTop: number,
+    outLeft: number,
+    inLeft: number
   ): [HTMLDivElement, HTMLDivElement] {
     let nodeOut = _renderNode(
       id,
@@ -244,6 +268,8 @@ export module GraphHTML {
       inner.value.returns,
       inner.outgoing_buttons,
       inner.incoming_buttons,
+      outTop,
+      outLeft
     )
     let nodeIn = _renderNode(
       id,
@@ -254,6 +280,8 @@ export module GraphHTML {
       [],
       inner.outgoing_buttons,
       inner.incoming_buttons,
+      inTop,
+      inLeft
     )
     // only affect the correct edges when dragged
     _dragElement(nodeOut, inner.outgoing_edges, []);

--- a/src/main/graph_html.ts
+++ b/src/main/graph_html.ts
@@ -8,22 +8,23 @@ const TOP_INITIAL = 100;
 const TOP_DELTA = 120;
 const LEFT_INITIAL = 30;
 const LEFT_DELTA = 170;
+const UNCONNECTED_LEFT = 30;
+const UNCONNECTED_TOP_INITIAL = 50;
+const UNCONNECTED_VERTICAL_DELTA = 100;
 const COLS = 4
 let nnodes = 0
 
 let vCoordUnconnectedNode = {
-  coord: -30,
+  coord: UNCONNECTED_TOP_INITIAL,
 };
 export { vCoordUnconnectedNode }
 
 function _nextNodeLocation(): { top: number, left: number } {
-  let row = Math.floor(nnodes / COLS)
-  let col = nnodes - row * COLS
   nnodes += 1
-  vCoordUnconnectedNode.coord = vCoordUnconnectedNode.coord + 100
+  vCoordUnconnectedNode.coord = vCoordUnconnectedNode.coord + UNCONNECTED_VERTICAL_DELTA
   return {
     top: vCoordUnconnectedNode.coord,
-    left: 900,
+    left: UNCONNECTED_LEFT,
   }
 }
 
@@ -144,12 +145,12 @@ export module GraphHTML {
     outputs: string[],
     outgoingButtons: HTMLButtonElement[],
     incomingButtons: HTMLButtonElement[],
-    top: number,
-    left: number
+    top?: number,
+    left?: number
   ): HTMLDivElement {
     let node = document.createElement("div");
     node.className = "node " + ty;
-    if(top == -1){
+    if(typeof top == 'undefined'){
       let loc = _nextNodeLocation()
       node.style.top = loc.top.toString() + 'px';
       node.setAttribute('top', loc.top.toString())
@@ -233,56 +234,100 @@ export module GraphHTML {
     }
   }
 
-  export function renderModule(id: string, inner: ModuleInner, top: number, left: number): HTMLDivElement {
-    let node = _renderNode(
-      id,
-      'module',
-      inner.value.description.params,
-      inner.value.description.returns,
-      inner.value.params,
-      inner.value.returns,
-      inner.outgoing_buttons,
-      inner.incoming_buttons,
-      top,
-      left
-    )
+  export function renderModule(id: string, inner: ModuleInner, top?: number, left?: number): HTMLDivElement {
+    let node
+    if(typeof top != 'undefined'){
+      node = _renderNode(
+        id,
+        'module',
+        inner.value.description.params,
+        inner.value.description.returns,
+        inner.value.params,
+        inner.value.returns,
+        inner.outgoing_buttons,
+        inner.incoming_buttons,
+        top,
+        left
+      )
+    } else {
+      node = _renderNode(
+        id,
+        'module',
+        inner.value.description.params,
+        inner.value.description.returns,
+        inner.value.params,
+        inner.value.returns,
+        inner.outgoing_buttons,
+        inner.incoming_buttons,
+      )
+    }
     _dragElement(node, inner.outgoing_edges, inner.incoming_edges, inner);
     return node
   }
 
-  //set outTop, inTop to -1 if don't have values for them
   export function renderSensor(
     id: string,
     inner: SensorInner,
-    outTop: number,
-    inTop: number,
-    outLeft: number,
-    inLeft: number
+    outTop?: number,
+    inTop?: number,
+    outLeft?: number,
+    inLeft?: number
   ): [HTMLDivElement, HTMLDivElement] {
-    let nodeOut = _renderNode(
-      id,
-      'sensor',
-      {},
-      inner.value.description.returns,
-      [],
-      inner.value.returns,
-      inner.outgoing_buttons,
-      inner.incoming_buttons,
-      outTop,
-      outLeft
-    )
-    let nodeIn = _renderNode(
-      id,
-      'sensor',
-      inner.value.description.state_keys,
-      {},
-      inner.value.state_keys,
-      [],
-      inner.outgoing_buttons,
-      inner.incoming_buttons,
-      inTop,
-      inLeft
-    )
+    let nodeOut
+    let nodeIn
+    if(typeof outTop != 'undefined'){
+      nodeOut = _renderNode(
+        id,
+        'sensor',
+        {},
+        inner.value.description.returns,
+        [],
+        inner.value.returns,
+        inner.outgoing_buttons,
+        inner.incoming_buttons,
+        outTop,
+        outLeft
+      )
+    } else {
+      nodeOut = _renderNode(
+        id,
+        'sensor',
+        {},
+        inner.value.description.returns,
+        [],
+        inner.value.returns,
+        inner.outgoing_buttons,
+        inner.incoming_buttons,
+      )
+      
+    }
+    if(typeof inTop != 'undefined'){
+      nodeIn = _renderNode(
+        id,
+        'sensor',
+        inner.value.description.state_keys,
+        {},
+        inner.value.state_keys,
+        [],
+        inner.outgoing_buttons,
+        inner.incoming_buttons,
+        inTop,
+        inLeft
+      )
+    } else {
+      nodeIn = _renderNode(
+        id,
+        'sensor',
+        inner.value.description.state_keys,
+        {},
+        inner.value.state_keys,
+        [],
+        inner.outgoing_buttons,
+        inner.incoming_buttons,
+      )
+    }
+
+    
     // only affect the correct edges when dragged
     _dragElement(nodeOut, inner.outgoing_edges, []);
     _dragElement(nodeIn, [], inner.incoming_edges);

--- a/src/main/graph_html.ts
+++ b/src/main/graph_html.ts
@@ -134,7 +134,7 @@ export module GraphHTML {
     }
   }
 
-  //if top == -1, then go with _nextNodeLocation(), otherwise use
+  //if top == null, then go with _nextNodeLocation(), otherwise use
   //given height
   function _renderNode(
     id: string,
@@ -150,7 +150,7 @@ export module GraphHTML {
   ): HTMLDivElement {
     let node = document.createElement("div");
     node.className = "node " + ty;
-    if(typeof top == 'undefined'){
+    if(top == null){
       let loc = _nextNodeLocation()
       node.style.top = loc.top.toString() + 'px';
       node.setAttribute('top', loc.top.toString())

--- a/src/sidebar/sensor_html.ts
+++ b/src/sidebar/sensor_html.ts
@@ -19,7 +19,7 @@ export module SensorModals {
     if (sensors.hasOwnProperty(sensorId)) {
       sensors[sensorId].html.remove()
       Network.confirmSensor(sensorId)
-      g.add_sensor(sensors[sensorId].sensor, -1, -1, 1, -1)
+      g.add_sensor(sensors[sensorId].sensor)
       delete sensors[sensorId]
     } else {
       console.error(`failed to confirm missing sensor: ${sensorId}`)

--- a/src/sidebar/sensor_html.ts
+++ b/src/sidebar/sensor_html.ts
@@ -19,7 +19,7 @@ export module SensorModals {
     if (sensors.hasOwnProperty(sensorId)) {
       sensors[sensorId].html.remove()
       Network.confirmSensor(sensorId)
-      g.add_sensor(sensors[sensorId].sensor)
+      g.add_sensor(sensors[sensorId].sensor, -1, -1, 1, -1)
       delete sensors[sensorId]
     } else {
       console.error(`failed to confirm missing sensor: ${sensorId}`)


### PR DESCRIPTION
When we call setGraphFormat, the coordinates for where the nodes should be located are all pre-calculated. We use DP and recursion to find depth (see getNodeDepth() in graph.ts) of each node and use DP and multiple level-order traversals to find horizontal position (see getLevelOrderTraversal() in graph.ts) of each node. 

Additionally, add_sensor, addModuleWithId, and other related functions have been modified to allow us to pass in coordinates for where the nodes should be located (this was necessary because coordinates are pre-calculated instead of using _nextNodeLocation()). 

Nodes that do not have any edges, however, still use _nextNodeLocation(), but the function has been modified solely for the purpose of finding the coordinates of nodes that do not have edges.
